### PR TITLE
Unmount root if already mounted

### DIFF
--- a/src/render.ts
+++ b/src/render.ts
@@ -15,6 +15,11 @@ export function render(children: React.ReactNode) {
   const handleInit = (payload: any) => {
     const { props, drawingSurface: canvas, width, top, left, height, pixelRatio } = payload
     try {
+      // Unmount root if already mounted
+      if (root) {
+        root.unmount()
+      }
+
       // Shim the canvas into a fake window/document
       Object.assign(canvas, {
         pageXOffset: left,


### PR DESCRIPTION
Fixes #16

This change makes that the canvas can be re-rendered correctly without reloading the worker when the component is mounted.